### PR TITLE
Changed Neopixel pin on SAMD21 in FastLED to be Pin 3 in Arduino - to match new variant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,91 +2,86 @@
 [![arduino-library-badge](https://www.ardu-badge.com/badge/FastLED.svg)](https://www.ardu-badge.com/FastLED)
 ![build status](https://github.com/FastLED/FastLED/workflows/build/badge.svg)
 
-IMPORTANT NOTE: For AVR based systems, avr-gcc 4.8.x is supported and tested.  This means Arduino 1.6.5 and later.
+IMPORTANT NOTE: For AVR based systems, avr-gcc 4.8.x is supported and tested. This means Arduino 1.6.5 and later.
 
-
-FastLED 3.5
-===========
+# FastLED 3.5 - LEDGloves Fork
 
 This is a library for easily & efficiently controlling a wide variety of LED chipsets, like the ones
-sold by adafruit (Neopixel, DotStar, LPD8806), Sparkfun (WS2801), and aliexpress.  In addition to writing to the
+sold by adafruit (Neopixel, DotStar, LPD8806), Sparkfun (WS2801), and aliexpress. In addition to writing to the
 leds, this library also includes a number of functions for high-performing 8bit math for manipulating
 your RGB values, as well as low level classes for abstracting out access to pins and SPI hardware, while
 still keeping things as fast as possible. Tested with Arduino up to 1.6.5 from arduino.cc.
 
-Quick note for people installing from GitHub repo zips, rename the folder FastLED before copying it to your Arduino/libraries folder.  Github likes putting -branchname into the name of the folder, which unfortunately, makes Arduino cranky!
+Quick note for people installing from GitHub repo zips, rename the folder FastLED before copying it to your Arduino/libraries folder. Github likes putting -branchname into the name of the folder, which unfortunately, makes Arduino cranky!
 
 We have multiple goals with this library:
 
-* Quick start for new developers - hook up your leds and go, no need to think about specifics of the led chipsets being used
-* Zero pain switching LED chipsets - you get some new leds that the library supports, just change the definition of LEDs you're using, et. voila!  Your code is running with the new leds.
-* High performance - with features like zero cost global brightness scaling, high performance 8-bit math for RGB manipulation, and some of the fastest bit-bang'd SPI support around, FastLED wants to keep as many CPU cycles available for your led patterns as possible
+- Quick start for new developers - hook up your leds and go, no need to think about specifics of the led chipsets being used
+- Zero pain switching LED chipsets - you get some new leds that the library supports, just change the definition of LEDs you're using, et. voila! Your code is running with the new leds.
+- High performance - with features like zero cost global brightness scaling, high performance 8-bit math for RGB manipulation, and some of the fastest bit-bang'd SPI support around, FastLED wants to keep as many CPU cycles available for your led patterns as possible
 
 ## Getting help
 
-If you need help with using the library, please consider going to the reddit community first, which is at http://fastled.io/r (or https://reddit.com/r/FastLED) - there are thousands of great people in that group and many times you will get a quicker answer to your question there, as you will be likely to run into other people who have had the same issue.  If you run into bugs with the library (compilation failures, the library doing the wrong thing), or if you'd like to request that we support a particular platform or LED chipset, then please open an issue at http://fastled.io/issues and we will try to figure out what is going wrong.
+If you need help with using the library, please consider going to the reddit community first, which is at http://fastled.io/r (or https://reddit.com/r/FastLED) - there are thousands of great people in that group and many times you will get a quicker answer to your question there, as you will be likely to run into other people who have had the same issue. If you run into bugs with the library (compilation failures, the library doing the wrong thing), or if you'd like to request that we support a particular platform or LED chipset, then please open an issue at http://fastled.io/issues and we will try to figure out what is going wrong.
 
 ## Simple example
 
-How quickly can you get up and running with the library?  Here's a simple blink program:
+How quickly can you get up and running with the library? Here's a simple blink program:
 
-	#include "FastLED.h"
-	#define NUM_LEDS 60
-	CRGB leds[NUM_LEDS];
-	void setup() { FastLED.addLeds<NEOPIXEL, 6>(leds, NUM_LEDS); }
-	void loop() {
-		leds[0] = CRGB::White; FastLED.show(); delay(30);
-		leds[0] = CRGB::Black; FastLED.show(); delay(30);
-	}
+    #include "FastLED.h"
+    #define NUM_LEDS 60
+    CRGB leds[NUM_LEDS];
+    void setup() { FastLED.addLeds<NEOPIXEL, 6>(leds, NUM_LEDS); }
+    void loop() {
+    	leds[0] = CRGB::White; FastLED.show(); delay(30);
+    	leds[0] = CRGB::Black; FastLED.show(); delay(30);
+    }
 
 ## Supported LED chipsets
 
-Here's a list of all the LED chipsets are supported.  More details on the led chipsets are included [on our wiki page](https://github.com/FastLED/FastLED/wiki/Chipset-reference)
+Here's a list of all the LED chipsets are supported. More details on the led chipsets are included [on our wiki page](https://github.com/FastLED/FastLED/wiki/Chipset-reference)
 
-* Adafruit's DotStars - AKA the APA102
-* Adafruit's Neopixel - aka the WS2812B (also WS2811/WS2812/WS2813, also supported in lo-speed mode) - a 3 wire addressable led chipset
-* TM1809/4 - 3 wire chipset, cheaply available on aliexpress.com
-* TM1803 - 3 wire chipset, sold by radio shack
-* UCS1903 - another 3 wire led chipset, cheap
-* GW6205 - another 3 wire led chipset
-* LPD8806 - SPI based chipset, very high speed
-* WS2801 - SPI based chipset, cheap and widely available
-* SM16716 - SPI based chipset
-* APA102 - SPI based chipset
-* P9813 - aka Cool Neon's Total Control Lighting
-* DMX - send rgb data out over DMX using arduino DMX libraries
-* SmartMatrix panels - needs the SmartMatrix library - https://github.com/pixelmatix/SmartMatrix
-* LPD6803 - SPI based chpiset, chip CMODE pin must be set to 1 (inside oscillator mode)
+- Adafruit's DotStars - AKA the APA102
+- Adafruit's Neopixel - aka the WS2812B (also WS2811/WS2812/WS2813, also supported in lo-speed mode) - a 3 wire addressable led chipset
+- TM1809/4 - 3 wire chipset, cheaply available on aliexpress.com
+- TM1803 - 3 wire chipset, sold by radio shack
+- UCS1903 - another 3 wire led chipset, cheap
+- GW6205 - another 3 wire led chipset
+- LPD8806 - SPI based chipset, very high speed
+- WS2801 - SPI based chipset, cheap and widely available
+- SM16716 - SPI based chipset
+- APA102 - SPI based chipset
+- P9813 - aka Cool Neon's Total Control Lighting
+- DMX - send rgb data out over DMX using arduino DMX libraries
+- SmartMatrix panels - needs the SmartMatrix library - https://github.com/pixelmatix/SmartMatrix
+- LPD6803 - SPI based chpiset, chip CMODE pin must be set to 1 (inside oscillator mode)
 
-
-HL1606, and "595"-style shift registers are no longer supported by the library.  The older Version 1 of the library ("FastSPI_LED") has support for these, but is missing many of the advanced features of current versions and is no longer being maintained.
-
+HL1606, and "595"-style shift registers are no longer supported by the library. The older Version 1 of the library ("FastSPI_LED") has support for these, but is missing many of the advanced features of current versions and is no longer being maintained.
 
 ## Supported platforms
 
-Right now the library is supported on a variety of arduino compatible platforms.  If it's ARM or AVR and uses the arduino software (or a modified version of it to build) then it is likely supported.  Note that we have a long list of upcoming platforms to support, so if you don't see what you're looking for here, ask, it may be on the roadmap (or may already be supported).  N.B. at the moment we are only supporting the stock compilers that ship with the arduino software.  Support for upgraded compilers, as well as using AVR studio and skipping the arduino entirely, should be coming in a near future release.
+Right now the library is supported on a variety of arduino compatible platforms. If it's ARM or AVR and uses the arduino software (or a modified version of it to build) then it is likely supported. Note that we have a long list of upcoming platforms to support, so if you don't see what you're looking for here, ask, it may be on the roadmap (or may already be supported). N.B. at the moment we are only supporting the stock compilers that ship with the arduino software. Support for upgraded compilers, as well as using AVR studio and skipping the arduino entirely, should be coming in a near future release.
 
-* Arduino & compatibles - straight up arduino devices, uno, duo, leonardo, mega, nano, etc...
-* Arduino Yún
-* Adafruit Trinket & Gemma - Trinket Pro may be supported, but haven't tested to confirm yet
-* Teensy 2, Teensy++ 2, Teensy 3.0, Teensy 3.1/3.2, Teensy LC, Teensy 3.5, Teensy 3.6, and Teensy 4.0 - arduino compatible from pjrc.com with some extra goodies (note the teensy LC, 3.2, 3.5, 3.6, 4.0 are ARM, not AVR!)
-* Arduino Due and the digistump DigiX
-* RFDuino
-* SparkCore
-* Arduino Zero
-* ESP8266 using the arduino board definitions from http://arduino.esp8266.com/stable/package_esp8266com_index.json - please be sure to also read https://github.com/FastLED/FastLED/wiki/ESP8266-notes for information specific to the 8266.
-* The wino board - http://wino-board.com
-* ESP32 based boards
+- Arduino & compatibles - straight up arduino devices, uno, duo, leonardo, mega, nano, etc...
+- Arduino Yún
+- Adafruit Trinket & Gemma - Trinket Pro may be supported, but haven't tested to confirm yet
+- Teensy 2, Teensy++ 2, Teensy 3.0, Teensy 3.1/3.2, Teensy LC, Teensy 3.5, Teensy 3.6, and Teensy 4.0 - arduino compatible from pjrc.com with some extra goodies (note the teensy LC, 3.2, 3.5, 3.6, 4.0 are ARM, not AVR!)
+- Arduino Due and the digistump DigiX
+- RFDuino
+- SparkCore
+- Arduino Zero
+- ESP8266 using the arduino board definitions from http://arduino.esp8266.com/stable/package_esp8266com_index.json - please be sure to also read https://github.com/FastLED/FastLED/wiki/ESP8266-notes for information specific to the 8266.
+- The wino board - http://wino-board.com
+- ESP32 based boards
 
-What types of platforms are we thinking about supporting in the future?  Here's a short list:  ChipKit32, Maple, Beagleboard
+What types of platforms are we thinking about supporting in the future? Here's a short list: ChipKit32, Maple, Beagleboard
 
 ## What about that name?
 
-Wait, what happened to FastSPI_LED and FastSPI_LED2?  The library was initially named FastSPI_LED because it was focused on very fast and efficient SPI access.  However, since then, the library has expanded to support a number of LED chipsets that don't use SPI, as well as a number of math and utility functions for LED processing across the board.  We decided that the name FastLED more accurately represents the totality of what the library provides, everything fast, for LEDs.
+Wait, what happened to FastSPI_LED and FastSPI_LED2? The library was initially named FastSPI_LED because it was focused on very fast and efficient SPI access. However, since then, the library has expanded to support a number of LED chipsets that don't use SPI, as well as a number of math and utility functions for LED processing across the board. We decided that the name FastLED more accurately represents the totality of what the library provides, everything fast, for LEDs.
 
 ## For more information
 
 Check out the official site http://fastled.io for links to documentation, issues, and news
 
-
-*TODO* - get candy
+_TODO_ - get candy

--- a/library.json
+++ b/library.json
@@ -1,57 +1,59 @@
 {
-    "name": "FastLED_Millis",
-    "description": "FastLED is a library for programming addressable rgb led strips (APA102/Dotstar, WS2812/Neopixel, LPD8806, and a dozen others) acting both as a driver and as a library for color management and fast math.",
-    "keywords": "led,noise,rgb,math,fast",
-    "authors": [
-        {
-            "name": "Daniel Garcia",
-            "url": "https://github.com/focalintent",
-            "maintainer": true
-        },
-        {
-            "name": "Mark Kriegsman",
-            "url": "https://github.com/kriegsman",
-            "maintainer": true
-        },
-        {
-            "name": "Sam Guyer",
-            "url": "https://github.com/samguyer",
-            "maintainer": true
-        },
-        {
-            "name": "Jason Coon",
-            "url": "https://github.com/jasoncoon",
-            "maintainer": true
-        },
-        {
-            "name": "Josh Huber",
-            "url": "https://github.com/uberjay",
-            "maintainer": true
-        }
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/FastLED/FastLED.git"
+  "name": "FastLED - LEDGloves Fork",
+  "description": "Forked from FastLED/FastLED <3",
+  "keywords": "led,noise,rgb,math,fast",
+  "authors": [
+    {
+      "name": "Daniel Garcia",
+      "url": "https://github.com/focalintent",
+      "maintainer": true
     },
-    "version": "3.5.0",
-    "license": "MIT",
-    "homepage": "http://fastled.io",
-    "frameworks": "arduino",
-    "platforms": "atmelavr, atmelsam, freescalekinetis, nordicnrf51, nxplpc, ststm32, teensy, espressif8266, espressif32, nordicnrf52",
-    "headers": "FastLED.h",
-    "export": {
-        "exclude": [
-            "docs",
-            "extras"
-        ]
+    {
+      "name": "Mark Kriegsman",
+      "url": "https://github.com/kriegsman",
+      "maintainer": true
     },
-    "build": {
-        "srcFilter": [
-            "+<*.c>",
-            "+<*.cpp>",
-            "+<*.h>",
-            "+<platforms/esp/32/*.cpp>"
-        ],
-        "libArchive": false
+    {
+      "name": "Sam Guyer",
+      "url": "https://github.com/samguyer",
+      "maintainer": true
+    },
+    {
+      "name": "Jason Coon",
+      "url": "https://github.com/jasoncoon",
+      "maintainer": true
+    },
+    {
+      "name": "Josh Huber",
+      "url": "https://github.com/uberjay",
+      "maintainer": true
+    },
+    {
+      "name": "Jarrad Fallon",
+      "url": "https://github.com/sumyumguy92",
+      "maintainer": true
+    },
+    {
+      "name": "Rayce Stipanovich",
+      "url": "https://github.com/musicmindmachine",
+      "maintainer": true
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/musicmindmachine/FastLED---LEDGloves-Fork.git"
+  },
+  "version": "3.5.1",
+  "license": "MIT",
+  "homepage": "http://fastled.io",
+  "frameworks": "arduino",
+  "platforms": "atmelavr, atmelsam, freescalekinetis, nordicnrf51, nxplpc, ststm32, teensy, espressif8266, espressif32, nordicnrf52",
+  "headers": "FastLED.h",
+  "export": {
+    "exclude": ["docs", "extras"]
+  },
+  "build": {
+    "srcFilter": ["+<*.c>", "+<*.cpp>", "+<*.h>", "+<platforms/esp/32/*.cpp>"],
+    "libArchive": false
+  }
 }

--- a/library.json
+++ b/library.json
@@ -43,7 +43,7 @@
     "type": "git",
     "url": "https://github.com/musicmindmachine/FastLED---LEDGloves-Fork.git"
   },
-  "version": "3.5.1",
+  "version": "3.5.2",
   "license": "MIT",
   "homepage": "http://fastled.io",
   "frameworks": "arduino",

--- a/library.json
+++ b/library.json
@@ -43,7 +43,7 @@
     "type": "git",
     "url": "https://github.com/musicmindmachine/FastLED---LEDGloves-Fork.git"
   },
-  "version": "3.5.2",
+  "version": "3.5.3",
   "license": "MIT",
   "homepage": "http://fastled.io",
   "frameworks": "arduino",

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -586,7 +586,7 @@ extern CFastLED FastLED;
 
 // Warnings for undefined things
 #ifndef HAS_HARDWARE_PIN_SUPPORT
-//#warning "No pin/port mappings found, pin access will be slightly slower. See fastpin.h for info."
+#warning "No pin/port mappings found, pin access will be slightly slower. See fastpin.h for info."
 #define NO_HARDWARE_PIN_SUPPORT
 #endif
 

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -8,13 +8,13 @@
 #define FASTLED_HAS_PRAGMA_MESSAGE
 #endif
 
-#define FASTLED_VERSION 3005000
+#define FASTLED_VERSION 3005001
 #ifndef FASTLED_INTERNAL
 #  ifdef  FASTLED_SHOW_VERSION
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "FastLED version 3.005.000"
+#      pragma message "FastLED version 3.005.001"
 #    else
-#      warning FastLED version 3.005.000  (Not really a warning, just telling you here.)
+#      warning FastLED version 3.005.001  (Not really a warning, just telling you here.)
 #    endif
 #  endif
 #endif
@@ -586,7 +586,7 @@ extern CFastLED FastLED;
 
 // Warnings for undefined things
 #ifndef HAS_HARDWARE_PIN_SUPPORT
-#warning "No pin/port mappings found, pin access will be slightly slower. See fastpin.h for info."
+//#warning "No pin/port mappings found, pin access will be slightly slower. See fastpin.h for info."
 #define NO_HARDWARE_PIN_SUPPORT
 #endif
 

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -12,9 +12,9 @@
 #ifndef FASTLED_INTERNAL
 #  ifdef  FASTLED_SHOW_VERSION
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "FastLED version 3.005.002"
+#      pragma message "FastLED version 3.005.003"
 #    else
-#      warning FastLED version 3.005.002  (Not really a warning, just telling you here.)
+#      warning FastLED version 3.005.003  (Not really a warning, just telling you here.)
 #    endif
 #  endif
 #endif

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -12,9 +12,9 @@
 #ifndef FASTLED_INTERNAL
 #  ifdef  FASTLED_SHOW_VERSION
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "FastLED version 3.005.001"
+#      pragma message "FastLED version 3.005.002"
 #    else
-#      warning FastLED version 3.005.001  (Not really a warning, just telling you here.)
+#      warning FastLED version 3.005.002  (Not really a warning, just telling you here.)
 #    endif
 #  endif
 #endif

--- a/src/fastspi.h
+++ b/src/fastspi.h
@@ -147,9 +147,9 @@ class SPIOutput<SPI_DATA, SPI_CLOCK, SPI_SPEED> : public ArdunioCoreSPIOutput<SP
 #else
 #  if !defined(FASTLED_INTERNAL) && !defined(FASTLED_ALL_PINS_HARDWARE_SPI)
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
+#      //pragma message "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
 #    else
-#      warning "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
+#      //warning "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
 #    endif
 #  endif
 #endif
@@ -162,9 +162,9 @@ class SPIOutput<SPI_DATA, SPI_CLOCK, SPI_SPEED> : public ArdunioCoreSPIOutput<SP
 #else
 #  if !defined(FASTLED_INTERNAL) && !defined(FASTLED_ALL_PINS_HARDWARE_SPI)
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      pragma message "Forcing software SPI - no hardware SPI for you!"
+#      //pragma message "Forcing software SPI - no hardware SPI for you!"
 #    else
-#      warning "Forcing software SPI - no hardware SPI for you!"
+#      //warning "Forcing software SPI - no hardware SPI for you!"
 #    endif
 #  endif
 #endif

--- a/src/fastspi.h
+++ b/src/fastspi.h
@@ -147,9 +147,9 @@ class SPIOutput<SPI_DATA, SPI_CLOCK, SPI_SPEED> : public ArdunioCoreSPIOutput<SP
 #else
 #  if !defined(FASTLED_INTERNAL) && !defined(FASTLED_ALL_PINS_HARDWARE_SPI)
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      //pragma message "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
+#      pragma message "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
 #    else
-#      //warning "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
+#      warning "No hardware SPI pins defined.  All SPI access will default to bitbanged output"
 #    endif
 #  endif
 #endif
@@ -162,9 +162,9 @@ class SPIOutput<SPI_DATA, SPI_CLOCK, SPI_SPEED> : public ArdunioCoreSPIOutput<SP
 #else
 #  if !defined(FASTLED_INTERNAL) && !defined(FASTLED_ALL_PINS_HARDWARE_SPI)
 #    ifdef FASTLED_HAS_PRAGMA_MESSAGE
-#      //pragma message "Forcing software SPI - no hardware SPI for you!"
+#     pragma message "Forcing software SPI - no hardware SPI for you!"
 #    else
-#      //warning "Forcing software SPI - no hardware SPI for you!"
+#      warning "Forcing software SPI - no hardware SPI for you!"
 #    endif
 #  endif
 #endif

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -4,7 +4,7 @@
 FASTLED_NAMESPACE_BEGIN
 
 #if defined(FASTLED_FORCE_SOFTWARE_PINS)
-//#warning "Software pin support forced, pin access will be slightly slower."
+#warning "Software pin support forced, pin access will be slightly slower."
 #define NO_HARDWARE_PIN_SUPPORT
 #undef HAS_HARDWARE_PIN_SUPPORT
 

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -4,7 +4,7 @@
 FASTLED_NAMESPACE_BEGIN
 
 #if defined(FASTLED_FORCE_SOFTWARE_PINS)
-#warning "Software pin support forced, pin access will be slightly slower."
+//#warning "Software pin support forced, pin access will be slightly slower."
 #define NO_HARDWARE_PIN_SUPPORT
 #undef HAS_HARDWARE_PIN_SUPPORT
 

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -236,7 +236,7 @@ _FL_DEFPIN( 3, 7, 0); _FL_DEFPIN( 4, 6, 0); _FL_DEFPIN( 7, 0, 0); _FL_DEFPIN( 8,
 #elif defined(ADAFRUIT_QTPY_M0)
 
 #define MAX_PIN 10
-_FL_DEFPIN( 0, 2, 0); _FL_DEFPIN( 1, 3, 0); _FL_DEFPIN( 2, 4, 0); _FL_DEFPIN( 3, 5, 0);
+_FL_DEFPIN( 0, 3, 0); _FL_DEFPIN( 1, 0, 0); _FL_DEFPIN( 2, 4, 0); _FL_DEFPIN( 3, 5, 0);
 _FL_DEFPIN( 4, 16, 0); _FL_DEFPIN( 5, 17, 0); _FL_DEFPIN( 6, 6, 0); _FL_DEFPIN( 7, 7, 0);
 _FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0);
 

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -235,10 +235,10 @@ _FL_DEFPIN( 3, 7, 0); _FL_DEFPIN( 4, 6, 0); _FL_DEFPIN( 7, 0, 0); _FL_DEFPIN( 8,
 
 #elif defined(ADAFRUIT_QTPY_M0)
 
-#define MAX_PIN 10
+#define MAX_PIN 11
 _FL_DEFPIN( 0, 3, 0); _FL_DEFPIN( 1, 0, 0); _FL_DEFPIN( 2, 4, 0); _FL_DEFPIN( 3, 5, 0);
 _FL_DEFPIN( 4, 16, 0); _FL_DEFPIN( 5, 17, 0); _FL_DEFPIN( 6, 6, 0); _FL_DEFPIN( 7, 7, 0);
-_FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0);
+_FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0); _FL_DEFPIN( 11, 18, 0);
 
 #define SPI_DATA  10
 #define SPI_CLOCK 8

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -235,10 +235,10 @@ _FL_DEFPIN( 3, 7, 0); _FL_DEFPIN( 4, 6, 0); _FL_DEFPIN( 7, 0, 0); _FL_DEFPIN( 8,
 
 #elif defined(ADAFRUIT_QTPY_M0)
 
-#define MAX_PIN 11
-_FL_DEFPIN( 0, 3, 0); _FL_DEFPIN( 1, 0, 0); _FL_DEFPIN( 2, 4, 0); _FL_DEFPIN( 3, 5, 0);
+#define MAX_PIN 10
+_FL_DEFPIN( 0, 3, 0); _FL_DEFPIN( 1, 0, 0); _FL_DEFPIN( 2, 4, 0); _FL_DEFPIN( 3, 18, 0);
 _FL_DEFPIN( 4, 16, 0); _FL_DEFPIN( 5, 17, 0); _FL_DEFPIN( 6, 6, 0); _FL_DEFPIN( 7, 7, 0);
-_FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0); _FL_DEFPIN( 11, 18, 0);
+_FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0); 
 
 #define SPI_DATA  10
 #define SPI_CLOCK 8


### PR DESCRIPTION
Enables Hardware FastPIN functionality on arduino pin3, which is configured to go to the Neopixel in a new custom board variant.